### PR TITLE
Delete extra closing square bracket in books def.

### DIFF
--- a/predicates.markdown
+++ b/predicates.markdown
@@ -321,7 +321,7 @@ some awards.
 (def scanner-darkly {:title "A Scanner Darkly" :authors #{dick}})
 
 (def books #{cities, wild-seed, lord-of-light,
-             deus-irae, ysabel, scanner-darkly}])
+             deus-irae, ysabel, scanner-darkly})
 ~~~
 
 


### PR DESCRIPTION
The books def in the write-up above exercise seven in the predicates
chapter had an extra closing square bracket which was an invalid
expression. Removed the bracket and it is now a valid expression.
