### PR TITLE
Fix unmatched delimiter for copy-pasta.

### DIFF
--- a/predicates.markdown
+++ b/predicates.markdown
@@ -321,7 +321,7 @@ some awards.
 (def scanner-darkly {:title "A Scanner Darkly" :authors #{dick}})
 
 (def books #{cities, wild-seed, lord-of-light,
-             deus-irae, ysabel, scanner-darkly}])
+             deus-irae, ysabel, scanner-darkly})
 ~~~
 
 


### PR DESCRIPTION
Removed extra `]`
