### PR TITLE
Correction to final sample output of (pred-and)

### DIFF
--- a/one-function-to-rule-them-all.markdown
+++ b/one-function-to-rule-them-all.markdown
@@ -481,7 +481,7 @@ any amount of parameters.
 (filter (pred-and) [1 0 -2])                    ;=> (1 0 -2)
 (filter (pred-and pos? odd?) [1 2 -4 0 6 7 -3]) ;=> (1 7)
 (filter (pred-and number? integer? pos? even?)
-        [1 0 -2 :a 7 "a" 2])                    ;=> (0 2)
+        [1 0 -2 :a 7 "a" 2])                    ;=> (2)
 ~~~
 
 </exercise>


### PR DESCRIPTION
In the third example for Exercise 12, `(pred-and)`, the call and return as given incorrectly as:

``` clojure
(filter (pred-and number? integer? pos? even?)
        [1 0 -2 :a 7 "a" 2])                   ;=> (0 2)
```

`(pos? 0)` returns `false`, however, so it should not appear in the list returned by filter. The result should only be `(2)`.

I've corrected the example accordingly.
